### PR TITLE
Images fit containers, even if large or horizontal

### DIFF
--- a/client/src/components/DiscoverCarousel.js
+++ b/client/src/components/DiscoverCarousel.js
@@ -61,14 +61,14 @@ const DiscoverCarousel = () => {
                 ({ primaryPhoto, _id, username }) => (
                   <Link to={`/closet/${username}`}>
                     <div className="card-container">
-                      <img className="card" src={primaryPhoto} alt={username} />
+                      <img className="card" src={primaryPhoto} alt={username} style = {{objectFit: 'contain'}}/>
                     </div>
                   </Link>
                 )
               )
             : images.map(({ id, img }) => (
                 <div key={id} className="card-container">
-                  <img className="card" src={img} alt="profile-pic" />
+                  <img className="card" src={img} alt="profile-pic" style = {{objectFit: 'contain'}} />
                 </div>
               ))}
         </div>

--- a/client/src/components/Items.js
+++ b/client/src/components/Items.js
@@ -128,13 +128,12 @@ const Items = ({ windowSize, userData }) => {
                         <MenuItem onClick={handleCloseMenu}>Delete</MenuItem>
                       </Menu>
                       <img
-                        // added contain property so large and horizontal images fit properly in gallery
-                        style={{ objectFit: 'contain' }}
                         src={`${photo}?w=248&fit=crop&auto=format`}
                         srcSet={`${photo}?w=248&fit=crop&auto=format&dpr=2 2x`}
                         alt="alt goes here"
                         loading="lazy"
                         className="item-img"
+                        style={{ objectFit: 'contain' }}
                       />
                       <ImageListItemBar
                         className="item-text"
@@ -155,7 +154,11 @@ const Items = ({ windowSize, userData }) => {
                   >
                     <Box sx={style} className="modal-box">
                       <div className="item-modal-pic">
-                        <img src={modalItemProps.photo} alt="img" />
+                        <img
+                          src={modalItemProps.photo}
+                          alt="img"
+                          style={{ objectFit: 'contain' }}
+                        />
                       </div>
                       <div className="item-modal-text">
                         <div className="item-name-more-div">
@@ -194,9 +197,9 @@ const Items = ({ windowSize, userData }) => {
                           <div className="review-header">
                             <div className="avatar-pic-div">
                               <img
-                                style={{ objectFit: 'contain' }}
                                 src={userData?.primaryPhoto}
                                 alt="img-alt"
+                                style={{ objectFit: 'contain' }}
                               />
                             </div>
                             <div className="username-div">

--- a/client/src/components/Items.js
+++ b/client/src/components/Items.js
@@ -31,13 +31,14 @@ const Items = ({ windowSize, userData }) => {
     size: '',
     link: '',
     photo: '',
-    review: ''
-  })
+    review: '',
+  });
 
   const handleOpen = (e) => {
     console.log(e.currentTarget);
-    const capitalizeFirstLetter = (str) => str.charAt(0).toUpperCase() + str.slice(1);
- 
+    const capitalizeFirstLetter = (str) =>
+      str.charAt(0).toUpperCase() + str.slice(1);
+
     setModalItemProps({
       _id: e.currentTarget.getAttribute('data-id'),
       category: e.currentTarget.getAttribute('data-category'),
@@ -47,9 +48,9 @@ const Items = ({ windowSize, userData }) => {
       link: e.currentTarget.getAttribute('data-link'),
       photo: e.currentTarget.getAttribute('data-photo'),
       review: e.currentTarget.getAttribute('data-review'),
-    })
+    });
     setOpen(true);
-  }
+  };
   const handleClose = () => setOpen(false);
 
   // more icon that opens edit/delete MUI menu
@@ -72,86 +73,45 @@ const Items = ({ windowSize, userData }) => {
         cols={windowSize.width > 766 ? 3 : 2}
         gap={window.innerWidth > 339 ? 16 : 8}
       >
-        {userData?.closet ? userData.closet.map(
-          ({
-            _id,
-            category,
-            brand,
-            gender,
-            name,
-            photo,
-            review,
-            size,
-            username,
-            link
-          }) => (
-            <div key={_id} className="item-list-wrapper">
-              {/* substitute heart icon for MoreVertIcon when closet does not belong to the person who is logged in */}
-              {/* <button>
+        {userData?.closet
+          ? userData.closet.map(
+              ({
+                _id,
+                category,
+                brand,
+                gender,
+                name,
+                photo,
+                review,
+                size,
+                username,
+                link,
+              }) => (
+                <div key={_id} className="item-list-wrapper">
+                  {/* substitute heart icon for MoreVertIcon when closet does not belong to the person who is logged in */}
+                  {/* <button>
               <FavoriteBorderIcon className="heart-icon icon" />
             </button> */}
-              <div data-id={_id} data-category={category} data-brand={brand} data-name={name} data-size={size} data-link={link} data-photo={photo} data-review={review} type="button" onClick={handleOpen}>
-                <ImageListItem >
-                  <MoreVertIcon
-                    id="basic-button"
-                    aria-controls={openMenu ? 'basic-menu' : undefined}
-                    aria-haspopup="true"
-                    aria-expanded={openMenu ? 'true' : undefined}
-                    onClick={handleClick}
-                    className="more-icon icon"
-                  />
-                  <Menu
-                    id="basic-menu"
-                    elevation={0}
-                    className="dropdown-menu"
-                    anchorEl={anchorEl}
-                    open={openMenu}
-                    onClose={handleCloseMenu}
-                    MenuListProps={{
-                      'aria-labelledby': 'basic-button',
-                    }}
+                  <div
+                    data-id={_id}
+                    data-category={category}
+                    data-brand={brand}
+                    data-name={name}
+                    data-size={size}
+                    data-link={link}
+                    data-photo={photo}
+                    data-review={review}
+                    type="button"
+                    onClick={handleOpen}
                   >
-                    <MenuItem onClick={handleCloseMenu}>Edit</MenuItem>
-                    <MenuItem onClick={handleCloseMenu}>Delete</MenuItem>
-                  </Menu>
-                  <img
-                    src={`${photo}?w=248&fit=crop&auto=format`}
-                    srcSet={`${photo}?w=248&fit=crop&auto=format&dpr=2 2x`}
-                    alt="alt goes here"
-                    loading="lazy"
-                    className="item-img"
-                  />
-                  <ImageListItemBar
-                    className="item-text"
-                    title={name}
-                    subtitle={`${brand} ${category}`}
-                    position="below"
-                  />
-                </ImageListItem>
-              </div>
-              {/* modularizing the item modal is currently not working */}
-              {/* <ItemModal /> */}
-              <Modal
-                aria-labelledby="unstyled-modal-title"
-                aria-describedby="unstyled-modal-description"
-                open={open}
-                onClose={handleClose}
-                BackdropComponent={Backdrop}
-              >
-                <Box sx={style} className="modal-box">
-                  <div className="item-modal-pic">
-                    <img src={modalItemProps.photo} alt="img" />
-                  </div>
-                  <div className="item-modal-text">
-                    <div className="item-name-more-div">
-                      <h1>{modalItemProps.name}</h1>
+                    <ImageListItem>
                       <MoreVertIcon
                         id="basic-button"
                         aria-controls={openMenu ? 'basic-menu' : undefined}
                         aria-haspopup="true"
                         aria-expanded={openMenu ? 'true' : undefined}
                         onClick={handleClick}
-                        className="icon-p"
+                        className="more-icon icon"
                       />
                       <Menu
                         id="basic-menu"
@@ -167,37 +127,98 @@ const Items = ({ windowSize, userData }) => {
                         <MenuItem onClick={handleCloseMenu}>Edit</MenuItem>
                         <MenuItem onClick={handleCloseMenu}>Delete</MenuItem>
                       </Menu>
-                    </div>
-                    <p>{`${modalItemProps.brand} ${modalItemProps.category}`}</p>
-                    <p>Size: {modalItemProps.size}</p>
-                    <Button className="shop-btn" variant="contained">
-                      Shop
-                    </Button>
-                    <div className="review-div">
-                      <div className="review-header">
-                        <div className="avatar-pic-div">
-                          <img
-                            src={userData?.primaryPhoto}
-                            alt="img-alt"
+                      <img
+                        // added contain property so large and horizontal images fit properly in gallery
+                        style={{ objectFit: 'contain' }}
+                        src={`${photo}?w=248&fit=crop&auto=format`}
+                        srcSet={`${photo}?w=248&fit=crop&auto=format&dpr=2 2x`}
+                        alt="alt goes here"
+                        loading="lazy"
+                        className="item-img"
+                      />
+                      <ImageListItemBar
+                        className="item-text"
+                        title={name}
+                        subtitle={`${brand} ${category}`}
+                        position="below"
+                      />
+                    </ImageListItem>
+                  </div>
+                  {/* modularizing the item modal is currently not working */}
+                  {/* <ItemModal /> */}
+                  <Modal
+                    aria-labelledby="unstyled-modal-title"
+                    aria-describedby="unstyled-modal-description"
+                    open={open}
+                    onClose={handleClose}
+                    BackdropComponent={Backdrop}
+                  >
+                    <Box sx={style} className="modal-box">
+                      <div className="item-modal-pic">
+                        <img src={modalItemProps.photo} alt="img" />
+                      </div>
+                      <div className="item-modal-text">
+                        <div className="item-name-more-div">
+                          <h1>{modalItemProps.name}</h1>
+                          <MoreVertIcon
+                            id="basic-button"
+                            aria-controls={openMenu ? 'basic-menu' : undefined}
+                            aria-haspopup="true"
+                            aria-expanded={openMenu ? 'true' : undefined}
+                            onClick={handleClick}
+                            className="icon-p"
                           />
+                          <Menu
+                            id="basic-menu"
+                            elevation={0}
+                            className="dropdown-menu"
+                            anchorEl={anchorEl}
+                            open={openMenu}
+                            onClose={handleCloseMenu}
+                            MenuListProps={{
+                              'aria-labelledby': 'basic-button',
+                            }}
+                          >
+                            <MenuItem onClick={handleCloseMenu}>Edit</MenuItem>
+                            <MenuItem onClick={handleCloseMenu}>
+                              Delete
+                            </MenuItem>
+                          </Menu>
                         </div>
-                        <div className="username-div">
-                          <Link to={`/closet/${userData.username}`}>
-                            <p className="username">{userData.username}</p>
-                          </Link>
-                          <p className="user-measurements-displayed">
-                            {userData.height}" | {userData.weight}lbs
+                        <p>{`${modalItemProps.brand} ${modalItemProps.category}`}</p>
+                        <p>Size: {modalItemProps.size}</p>
+                        <Button className="shop-btn" variant="contained">
+                          Shop
+                        </Button>
+                        <div className="review-div">
+                          <div className="review-header">
+                            <div className="avatar-pic-div">
+                              <img
+                                style={{ objectFit: 'contain' }}
+                                src={userData?.primaryPhoto}
+                                alt="img-alt"
+                              />
+                            </div>
+                            <div className="username-div">
+                              <Link to={`/closet/${userData.username}`}>
+                                <p className="username">{userData.username}</p>
+                              </Link>
+                              <p className="user-measurements-displayed">
+                                {userData.height}" | {userData.weight}lbs
+                              </p>
+                            </div>
+                          </div>
+                          <p className="review-content">
+                            {modalItemProps.review}
                           </p>
                         </div>
                       </div>
-                      <p className="review-content">{modalItemProps.review}</p>
-                    </div>
-                  </div>
-                </Box>
-              </Modal>
-            </div>
-          )
-        ) : "" }
+                    </Box>
+                  </Modal>
+                </div>
+              )
+            )
+          : ''}
       </ImageList>
     </div>
   );

--- a/client/src/pages/Closet.js
+++ b/client/src/pages/Closet.js
@@ -33,7 +33,7 @@ const Closet = ({ windowSize }) => {
       <div className="white-div"></div>
       <div className="profile-head">
         <div className="profile-img-div">
-          <img src={userData.primaryPhoto} alt={userData.primaryPhoto}/>
+          <img src={userData.primaryPhoto} alt={userData.primaryPhoto} style = {{objectFit: 'contain'}}/>
           <h2>{userData.username}</h2>
           <div className="folls-div">
             <a href="tbd">

--- a/client/src/pages/DiscoverFeed.js
+++ b/client/src/pages/DiscoverFeed.js
@@ -66,6 +66,8 @@ const DiscoverFeed = () => {
                         <div className="card-container" id="card-container">
                           <img
                             className="card"
+                            // added contain property so large and horizontal images fit properly in gallery
+                            style = {{objectFit: 'contain'}}
                             src={primaryPhoto}
                             alt={username}
                           />


### PR DESCRIPTION
Avoids image distortion or blurry partially appearing images if too large for the container. 
Updated in  discover feed, discover carousel, closet and items. 
Prettier auto-formatting applied to those files on save, sorry the code looks way different in the 'Files changed'. 
I just added 1 line  to the img properties :)
* style = {{objectFit: 'contain'}}

![image](https://user-images.githubusercontent.com/92805933/164310793-3f476d45-b460-4fbd-a8ef-031f69d8ea78.png)
